### PR TITLE
fix(lib/FixedPages): add trailingslash acc. to blog settings

### DIFF
--- a/lib/FixedPages.php
+++ b/lib/FixedPages.php
@@ -254,7 +254,7 @@ class FixedPages {
             }
         }
 
-        return $url;
+        return user_trailingslashit($url);
     }
 
     public function getConfigByPath($path) {


### PR DESCRIPTION
The `resolveUrl` function will return the correct URL with this change and not lead to an unnecessary redirect anymore.

Wasn't sure about adding tests since there are virtually none set up yet.